### PR TITLE
Make examples executable by adding comment char

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,8 +8,10 @@ Description: An RStudio addin that builds the skeleton of documentation for an R
     function or dataframe using the roxygen2 syntax.
 License: MIT + file LICENSE
 LazyData: TRUE
-RoxygenNote: 5.0.1
-Imports: rstudioapi
-Suggests: testthat
+RoxygenNote: 5.0.1.9000
+Imports:
+    rstudioapi
+Suggests:
+    testthat
 URL: https://github.com/mdlincoln/docthis
 BugReports: https://github.com/mdlincoln/docthis/issues

--- a/R/doc_this.R
+++ b/R/doc_this.R
@@ -33,7 +33,7 @@
 #' #'
 #' #' @return RETURN DESCRIPTION
 #' #' @examples
-#' #' ADD EXAMPLES HERE
+#' #' # ADD EXAMPLES HERE
 #'
 #' doc_this("iris")
 #' #' DATASET TITLE
@@ -114,6 +114,6 @@ doc_function <- function(obj, label) {
 #\'
 #\' @return RETURN DESCRIPTION
 #\' @examples
-#\' ADD EXAMPLES HERE
+#\' # ADD EXAMPLES HERE
 ", label)
 }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Say you've written a function (let's call it `lm`!) but haven't put together you
 #'
 #' @return RETURN DESCRIPTION
 #' @examples
-#' ADD EXAMPLES HERE
+#' # ADD EXAMPLES HERE
 lm <- function(.....
 ```
 

--- a/man/doc_this.Rd
+++ b/man/doc_this.Rd
@@ -45,7 +45,7 @@ doc_this("lm")
 #'
 #' @return RETURN DESCRIPTION
 #' @examples
-#' ADD EXAMPLES HERE
+#' # ADD EXAMPLES HERE
 
 doc_this("iris")
 #' DATASET TITLE


### PR DESCRIPTION
This is a small change that simply makes the default `examples{}` section comply with R CMD check by adding a leading comment character.
